### PR TITLE
Create init.sh for macOS development setup

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+
+# Install xCode cli tools
+if [[ "$(uname)" == "Darwin" ]]; then
+    echo "macOS deteted..."
+
+    if xcode-select -p &>/dev/null; then
+        echo "Xcode already installed"
+    else
+        echo "Installing commandline tools..."
+        xcode-select --install
+    fi
+fi
+
+# Install oh-my-zsh
+sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"
+
+# Homebrew
+## Install
+echo "Installing Brew..."
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+brew analytics off
+
+## Taps
+echo "Tapping Brew..."
+brew tap homebrew/cask-fonts
+brew tap FelixKratz/formulae
+
+## Formulae
+echo "Installing Brew Formulae..."
+
+## Core Utils
+echo "Install gnu coreutils"
+brew install coreutils
+
+### Must Have things
+brew install zsh-autosuggestions
+brew install zsh-syntax-highlighting
+brew install fzf
+brew install bat
+brew install fd
+brew install zoxide
+brew install lua
+brew install luajit
+brew install luarocks
+brew install prettier
+brew install make
+brew install qmk
+brew install ripgrep
+
+### Terminal
+brew install git
+brew install tmux
+brew install neovim
+
+brew install nvm
+brew install sqlite
+
+## Casks
+brew install --cask raycast
+brew install --cask keycastr
+brew install --cask font-hack-nerd-font
+brew install --cask font-jetbrains-mono-nerd-font
+brew install --cask font-sf-pro
+brew install --cask brave-browser
+
+## MacOS settings
+echo "Changing macOS defaults..."
+defaults write com.apple.Dock autohide -bool TRUE
+defaults write NSGlobalDomain KeyRepeat -int 2
+defaults write InitialKeyRepeat -int 15
+
+csrutil status
+echo "Installation complete..."
+
+# export gnu coreutils to path
+echo 'export PATH="/opt/homebrew/opt/coreutils/libexec/gnubin:$PATH"' >> ~/.zshrc
+
+echo "Dotfiles setup complete!"


### PR DESCRIPTION
This script installs essential development tools and configurations for macOS, including Xcode CLI tools, Homebrew, Oh My Zsh, and various formulae and casks.